### PR TITLE
Add RunOnceEx retrieval to Autoruns.ps1

### DIFF
--- a/CimSweep/ArtifactRetrieval/Autoruns.ps1
+++ b/CimSweep/ArtifactRetrieval/Autoruns.ps1
@@ -258,6 +258,17 @@ Outputs objects representing autoruns entries similar to the output of Sysintern
                             New-AutoRunsEntry -Category $Category
                     }
                 }
+                
+                $RunOnceExPaths = @(
+                    'SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx'
+                    'SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\RunOnceEx'
+                )
+
+                foreach ($RunOnceExPath in $RunOnceExPaths) {
+                    Get-CSRegistryKey -Hive HKLM -SubKey $AutoStartPath @CommonArgs |
+                        Get-CSRegistryValue |
+                            New-AutoRunsEntry -Category $Category
+                }
 
                 $null, 'Wow6432Node\' | ForEach-Object {
                     $InstalledComponents = "SOFTWARE\$($_)Microsoft\Active Setup\Installed Components"


### PR DESCRIPTION
Add detection of RunOnceEx key entries in HKLM

Autoruns.ps1 does not currently include the RunOnceEx subkeys, the potential nefariousness of which is documented here by Oddvar Me (@api0cradle) https://oddvar.moe/2018/03/21/persistence-using-runonceex-hidden-from-autoruns-exe/

**I haven't had a chance to test this yet**