### PR TITLE
Update DeviceGuard.ps1

### DIFF
--- a/CimSweep/Auditing/DeviceGuard.ps1
+++ b/CimSweep/Auditing/DeviceGuard.ps1
@@ -56,6 +56,7 @@ Outputs objects representing available and configured Device Guard settings.
             4 = 'SecureMemoryOverwrite'
             5 = 'UEFICodeReadOnly'
             6 = 'SMMSecurityMitigations1.0'
+            7 = 'ModeBasedExecutionControl'
         }
 
         # Also applies to UsermodeCodeIntegrityPolicyEnforcementStatus


### PR DESCRIPTION
According to [Enable virtualization-based protection of code integrity](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-exploit-guard/enable-virtualization-based-protection-of-code-integrity) AvailableSecurityProperty translates to MBEC (Mode-based execution control).